### PR TITLE
BAH-2436 | Use corretto as base image and as JDK in workflow

### DIFF
--- a/.github/workflows/pacs_simulator_build_publish.yml
+++ b/.github/workflows/pacs_simulator_build_publish.yml
@@ -30,9 +30,9 @@ jobs:
             echo "ARTIFACT_VERSION=$(echo $APP_VERSION-${{github.run_number}})" >> $GITHUB_ENV
           fi
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "8"
       - name: Setup Local Dependencies
         run: |

--- a/.github/workflows/pacs_simulator_validate_pr.yml
+++ b/.github/workflows/pacs_simulator_validate_pr.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "8"
       - name: Setup Local Dependencies
         run: |

--- a/Pacs_Simulator/package/docker/Dockerfile
+++ b/Pacs_Simulator/package/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 
 RUN mkdir -p /tmp/artifacts
 RUN mkdir -p /var/lib/bahmni
 
-RUN apk add curl postgresql-client
+RUN  yum install -y postgresql nc unzip
 
 RUN curl -L -o /tmp/artifacts/dcmsnd.zip https://sourceforge.net/projects/dcm4che/files/dcm4che2/2.0.28/dcm4che-2.0.28-bin.zip/download
 RUN unzip -d /var/lib/bahmni /tmp/artifacts/dcmsnd.zip


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)